### PR TITLE
Update r-devtools to 1.13.2.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '1.12.0' %}
+{% set version = '1.13.2' %}
 
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
@@ -12,7 +12,7 @@ source:
   url:
     - https://cran.r-project.org/src/contrib/devtools_{{ version }}.tar.gz
     - https://cran.r-project.org/src/contrib/Archive/devtools/devtools_{{ version }}.tar.gz
-  sha256: 8a3e2ca3988dffe29341e45a160bb588995eae43485d6a811a9ae4836d37afd4
+  sha256: fba85be24e854ea3f2b78ca67c5d616d1840704db46c39baa661342e42d65221
 
 build:
   number: 0
@@ -33,9 +33,6 @@ requirements:
     - r-rstudioapi >=0.2.0
     - r-whisker
     - r-withr
-    - posix                # [win]
-    - {{native}}toolchain  # [win]
-    - gcc                  # [not win]
 
   run:
     - r-base
@@ -47,7 +44,6 @@ requirements:
     - r-rstudioapi >=0.2.0
     - r-whisker
     - r-withr
-    - libgcc  # [not win]
 
 test:
   commands:
@@ -62,5 +58,6 @@ about:
 
 extra:
   recipe-maintainers:
+    - jdblischak
     - johanneskoester
     - bgruening


### PR DESCRIPTION
In addition to updating to the latest version of [r-devtools](https://cran.r-project.org/package=devtools), I also removed the dependency on a compiler. `conda skeleton cran devtools` does not include it, the recipe builds fine without it, and there was no discussion in the [original PR to staged-recipes](https://github.com/conda-forge/staged-recipes/pull/2906) to indicate why it was needed.

My guess is that the compiler dependency was added because [installing a compiler is recommended by r-devtools](https://github.com/hadley/devtools/tree/d3482c5ee63356f7b6f042b494bed5f11861e933#updating-to-the-latest-version-of-devtools) so that it can subsequently build R packages that contain code that needs to be compiled. If that is the case though, I would think that only the `libgcc` in `run:` would be needed since `gcc` is not needed to build r-devtools itself.

Please let me know if I should add back these dependencies.